### PR TITLE
Add task id as environment variable

### DIFF
--- a/handler/task.go
+++ b/handler/task.go
@@ -55,6 +55,11 @@ func createEremeticTask(request types.Request) (eremeticTask, error) {
 		})
 	}
 
+	environment = append(environment, &mesos.Environment_Variable{
+		Name:  proto.String("MESOS_TASK_ID"),
+		Value: proto.String(taskId),
+	})
+
 	task := eremeticTask{
 		ID:       taskId,
 		TaskCPUs: request.TaskCPUs,

--- a/handler/task_test.go
+++ b/handler/task_test.go
@@ -36,7 +36,7 @@ func TestTask(t *testing.T) {
 			So(task.deleteAt, ShouldBeZeroValue)
 			So(task.Container.GetType().String(), ShouldEqual, "DOCKER")
 			So(task.Container.Docker.GetImage(), ShouldEqual, "busybox")
-			So(task.Command.Environment.GetVariables(), ShouldBeEmpty)
+			So(task.Command.Environment.GetVariables(), ShouldHaveLength, 1)
 			So(task.Container.Volumes, ShouldBeEmpty)
 			So(task.Status, ShouldEqual, "TASK_STAGING")
 		})


### PR DESCRIPTION
The generated task id is exported as `MESOS_TASK_ID` just like marathon
does it.

https://mesosphere.github.io/marathon/docs/task-environment-vars.html