### PR TITLE
automatic version based on git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: all deps test docker
 
-DOCKERTAG?=eremetic
+VERSION?=$(shell git describe HEAD | sed s/^v//)
+DATE?=$(shell date -u '+%Y-%m-%d_%H:%M:%S')
+DOCKERTAG?=eremetic:${VERSION}
+LDFLAGS=-X main.Version '${VERSION}' -X main.BuildDate '${DATE}'
 SRC=$(shell find . -name '*.go')
 
 all: test
@@ -13,10 +16,10 @@ test: eremetic
 
 eremetic: deps
 eremetic: ${SRC}
-	go build -o $@
+	go build -ldflags "${LDFLAGS}" -o $@
 
 docker/eremetic: ${SRC}
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o $@
+	CGO_ENABLED=0 GOOS=linux go build -ldflags "${LDFLAGS}" -a -installsuffix cgo -o $@
 
 docker: docker/eremetic
 	docker build -t ${DOCKERTAG} docker

--- a/eremetic.go
+++ b/eremetic.go
@@ -13,8 +13,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const version = "0.3.0"
-
 func readConfig() {
 	path, _ := osext.ExecutableFolder()
 	viper.AddConfigPath("/etc/eremetic")
@@ -32,7 +30,7 @@ func setupLogging() {
 
 func main() {
 	if len(os.Args) == 2 && os.Args[1] == "--version" {
-		fmt.Println(version)
+		fmt.Println(Version)
 		os.Exit(0)
 	}
 	readConfig()

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package main
+
+var (
+	Version   = ""
+	BuildDate = ""
+)


### PR DESCRIPTION
Update makefile to set current version based on information in git. If
the current commit has a signed tag "v1.2.3" the current version will be
set to "1.2.3". If there is no tag for the current a version string
based on the latest tag as per `git describe` will be used.

Also sets a build date for good measure