### PR TITLE
Implement support for BoltDB database backing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 eremetic
 eremetic.yml
+db/*.db
 docker/static
 docker/templates

--- a/database/database.go
+++ b/database/database.go
@@ -20,6 +20,8 @@ func NewDB(file string) error {
 		dir, _ := os.Getwd()
 		file = fmt.Sprintf("%s/../%s", dir, file)
 	}
+	os.MkdirAll(filepath.Dir(file), 0755)
+
 	db, err := bolt.Open(file, 0600, nil)
 	boltdb = db
 	return err

--- a/database/database.go
+++ b/database/database.go
@@ -1,0 +1,95 @@
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alde/eremetic/types"
+	"github.com/boltdb/bolt"
+	"github.com/spf13/viper"
+)
+
+var boltdb *bolt.DB
+
+// NewDB is used to load the database handler into memory.
+// It will create a new database file if it doesn't already exist.
+func NewDB(file string) error {
+	if !filepath.IsAbs(file) {
+		dir, _ := os.Getwd()
+		file = fmt.Sprintf("%s/../%s", dir, file)
+	}
+	db, err := bolt.Open(file, 0600, nil)
+	boltdb = db
+	return err
+}
+
+// Clean is used to delete the tasks bucket
+func Clean() error {
+	return boltdb.Update(func(tx *bolt.Tx) error {
+		if err := tx.DeleteBucket([]byte("tasks")); err != nil {
+			return err
+		}
+		if _, err := tx.CreateBucketIfNotExists([]byte("tasks")); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// Close is used to Close the database
+func Close() {
+	if boltdb != nil {
+		boltdb.Close()
+	}
+}
+
+// PutTask stores a requested task in the database
+func PutTask(task *types.EremeticTask) error {
+	err := ensureDB()
+	if err != nil {
+		return err
+	}
+
+	return boltdb.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("tasks"))
+		if err != nil {
+			return err
+		}
+
+		encoded, err := json.Marshal(task)
+		if err != nil {
+			return err
+		}
+
+		return b.Put([]byte(task.ID), []byte(encoded))
+	})
+}
+
+// ReadTask fetches a task from the database
+func ReadTask(id string) (types.EremeticTask, error) {
+	var task types.EremeticTask
+
+	err := ensureDB()
+	if err != nil {
+		return task, err
+	}
+
+	err = boltdb.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("tasks"))
+		v := b.Get([]byte(id))
+		json.Unmarshal(v, &task)
+		return nil
+	})
+
+	return task, err
+}
+
+func ensureDB() error {
+	if boltdb == nil {
+		err := NewDB(viper.GetString("database"))
+		return err
+	}
+	return nil
+}

--- a/database/database.go
+++ b/database/database.go
@@ -1,12 +1,10 @@
 package database
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/alde/eremetic/types"
 	"github.com/boltdb/bolt"
 	"github.com/spf13/viper"
 )
@@ -45,47 +43,6 @@ func Close() {
 	if boltdb != nil {
 		boltdb.Close()
 	}
-}
-
-// PutTask stores a requested task in the database
-func PutTask(task *types.EremeticTask) error {
-	err := ensureDB()
-	if err != nil {
-		return err
-	}
-
-	return boltdb.Update(func(tx *bolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists([]byte("tasks"))
-		if err != nil {
-			return err
-		}
-
-		encoded, err := json.Marshal(task)
-		if err != nil {
-			return err
-		}
-
-		return b.Put([]byte(task.ID), []byte(encoded))
-	})
-}
-
-// ReadTask fetches a task from the database
-func ReadTask(id string) (types.EremeticTask, error) {
-	var task types.EremeticTask
-
-	err := ensureDB()
-	if err != nil {
-		return task, err
-	}
-
-	err = boltdb.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte("tasks"))
-		v := b.Get([]byte(id))
-		json.Unmarshal(v, &task)
-		return nil
-	})
-
-	return task, err
 }
 
 func ensureDB() error {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,100 @@
+package database
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alde/eremetic/types"
+	"github.com/gogo/protobuf/proto"
+	mesos "github.com/mesos/mesos-go/mesosproto"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func setup() error {
+	dir, _ := os.Getwd()
+	return NewDB(fmt.Sprintf("%s/../db/test.db", dir))
+}
+
+func TestDatabase(t *testing.T) {
+	Convey("NewDB", t, func() {
+		Convey("With an absolute path", func() {
+			err := setup()
+			defer Close()
+
+			So(boltdb.Path(), ShouldNotBeEmpty)
+			So(filepath.IsAbs(boltdb.Path()), ShouldBeTrue)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("With a relative path", func() {
+			NewDB("db/test.db")
+			defer Close()
+
+			dir, _ := os.Getwd()
+			So(filepath.IsAbs(boltdb.Path()), ShouldBeTrue)
+			So(boltdb.Path(), ShouldEqual, fmt.Sprintf("%s/../db/test.db", dir))
+		})
+	})
+
+	Convey("Close", t, func() {
+		setup()
+		Close()
+
+		So(boltdb.Path(), ShouldBeEmpty)
+	})
+
+	Convey("Clean", t, func() {
+		setup()
+		defer Close()
+
+		PutTask(&types.EremeticTask{ID: "1234"})
+		task, _ := ReadTask("1234")
+		So(task, ShouldNotEqual, types.EremeticTask{})
+		So(task.ID, ShouldNotBeEmpty)
+
+		Clean()
+
+		task, _ = ReadTask("1234")
+		So(task, ShouldBeZeroValue)
+	})
+
+	Convey("Put and Read Task", t, func() {
+		setup()
+		defer Close()
+
+		task1 := types.EremeticTask{ID: "1234"}
+		task2 := types.EremeticTask{
+			ID:       "12345",
+			TaskCPUs: 2.5,
+			TaskMem:  15.3,
+			Name:     "request Name",
+			Status:   mesos.TaskState_TASK_STAGING.String(),
+			Command: &mesos.CommandInfo{
+				Value: proto.String("echo date"),
+				User:  proto.String("root"),
+				Environment: &mesos.Environment{
+					Variables: nil,
+				},
+			},
+			Container: &mesos.ContainerInfo{
+				Type: mesos.ContainerInfo_DOCKER.Enum(),
+				Docker: &mesos.ContainerInfo_DockerInfo{
+					Image: proto.String("busybox"),
+				},
+				Volumes: nil,
+			},
+		}
+
+		PutTask(&task1)
+		PutTask(&task2)
+
+		t1, err := ReadTask(task1.ID)
+		So(t1, ShouldResemble, task1)
+		So(err, ShouldBeNil)
+		t2, err := ReadTask(task2.ID)
+		So(t2, ShouldResemble, task2)
+		So(err, ShouldBeNil)
+	})
+}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -66,11 +66,12 @@ func TestDatabase(t *testing.T) {
 
 		task1 := types.EremeticTask{ID: "1234"}
 		task2 := types.EremeticTask{
-			ID:       "12345",
-			TaskCPUs: 2.5,
-			TaskMem:  15.3,
-			Name:     "request Name",
-			Status:   mesos.TaskState_TASK_STAGING.String(),
+			ID:          "12345",
+			TaskCPUs:    2.5,
+			TaskMem:     15.3,
+			Name:        "request Name",
+			Status:      mesos.TaskState_TASK_STAGING.String(),
+			FrameworkId: "1234",
 			Command: &mesos.CommandInfo{
 				Value: proto.String("echo date"),
 				User:  proto.String("root"),

--- a/database/task.go
+++ b/database/task.go
@@ -1,0 +1,49 @@
+package database
+
+import (
+	"encoding/json"
+
+	"github.com/alde/eremetic/types"
+	"github.com/boltdb/bolt"
+)
+
+// PutTask stores a requested task in the database
+func PutTask(task *types.EremeticTask) error {
+	err := ensureDB()
+	if err != nil {
+		return err
+	}
+
+	return boltdb.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("tasks"))
+		if err != nil {
+			return err
+		}
+
+		encoded, err := json.Marshal(task)
+		if err != nil {
+			return err
+		}
+
+		return b.Put([]byte(task.ID), []byte(encoded))
+	})
+}
+
+// ReadTask fetches a task from the database
+func ReadTask(id string) (types.EremeticTask, error) {
+	var task types.EremeticTask
+
+	err := ensureDB()
+	if err != nil {
+		return task, err
+	}
+
+	err = boltdb.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("tasks"))
+		v := b.Get([]byte(id))
+		json.Unmarshal(v, &task)
+		return nil
+	})
+
+	return task, err
+}

--- a/eremetic.go
+++ b/eremetic.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/alde/eremetic/database"
 	"github.com/alde/eremetic/handler"
 	"github.com/alde/eremetic/routes"
 	log "github.com/dmuth/google-go-log4go"
@@ -20,6 +21,7 @@ func readConfig() {
 	viper.AutomaticEnv()
 	viper.SetConfigName("eremetic")
 	viper.SetDefault("loglevel", "debug")
+	viper.SetDefault("database", "db/eremetic.db")
 	viper.ReadInConfig()
 }
 
@@ -35,6 +37,8 @@ func main() {
 	}
 	readConfig()
 	setupLogging()
+	defer database.Close()
+
 	bind := fmt.Sprintf("%s:%d", viper.GetString("address"), viper.GetInt("port"))
 
 	// Catch interrupt
@@ -53,7 +57,6 @@ func main() {
 	router := routes.Create()
 	log.Infof("listening to %s", bind)
 	go handler.Run()
-	go handler.CleanupTasks()
 	err := http.ListenAndServe(bind, router)
 	if err != nil {
 		log.Error(err.Error())

--- a/eremetic.yml.example
+++ b/eremetic.yml.example
@@ -4,3 +4,4 @@ master: zk://<zookeeper_node1:port>,<zookeeper_node2:port>,(...)/mesos
 messenger_address: <callback address for mesos>
 messenger_port: <port for mesos to communicate on>
 loglevel: info
+database: db/eremetic.db

--- a/handler/scheduler.go
+++ b/handler/scheduler.go
@@ -63,6 +63,7 @@ func (s *eremeticScheduler) ResourceOffers(driver sched.SchedulerDriver, offers 
 			log.Debugf("Preparing to launch task %s with offer %s", tid, offer.Id.GetValue())
 			t, _ := database.ReadTask(tid)
 			task := s.newTask(offer, &t)
+			database.PutTask(&t)
 			driver.LaunchTasks([]*mesos.OfferID{offer.Id}, []*mesos.TaskInfo{task}, defaultFilter)
 			continue
 		default:

--- a/handler/scheduler.go
+++ b/handler/scheduler.go
@@ -3,8 +3,8 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
+	"github.com/alde/eremetic/database"
 	"github.com/alde/eremetic/types"
 	log "github.com/dmuth/google-go-log4go"
 	"github.com/gogo/protobuf/proto"
@@ -31,7 +31,7 @@ type eremeticScheduler struct {
 	done chan struct{}
 }
 
-func (s *eremeticScheduler) newTask(offer *mesos.Offer, spec *eremeticTask) *mesos.TaskInfo {
+func (s *eremeticScheduler) newTask(offer *mesos.Offer, spec *types.EremeticTask) *mesos.TaskInfo {
 	return createTaskInfo(spec, offer)
 }
 
@@ -61,9 +61,8 @@ func (s *eremeticScheduler) ResourceOffers(driver sched.SchedulerDriver, offers 
 			continue
 		case tid := <-s.tasks:
 			log.Debugf("Preparing to launch task %s with offer %s", tid, offer.Id.GetValue())
-			t := runningTasks[tid]
+			t, _ := database.ReadTask(tid)
 			task := s.newTask(offer, &t)
-			runningTasks[tid] = t
 			driver.LaunchTasks([]*mesos.OfferID{offer.Id}, []*mesos.TaskInfo{task}, defaultFilter)
 			continue
 		default:
@@ -77,10 +76,9 @@ func (s *eremeticScheduler) ResourceOffers(driver sched.SchedulerDriver, offers 
 func updateStatusForTask(status *mesos.TaskStatus) {
 	id := status.TaskId.GetValue()
 	log.Debugf("TaskId [%s] status [%s]", id, status.State)
-	task := runningTasks[id]
-	task.deleteAt = time.Now().Add(time.Hour)
+	task, _ := database.ReadTask(id)
 	task.Status = status.State.String()
-	runningTasks[id] = task
+	database.PutTask(&task)
 }
 
 // StatusUpdate takes care of updating the status
@@ -153,7 +151,7 @@ func scheduleTask(s *eremeticScheduler, request types.Request) (string, error) {
 		return "", err
 	}
 
-	runningTasks[task.ID] = task
+	database.PutTask(&task)
 	s.tasks <- task.ID
 	return task.ID, nil
 }

--- a/handler/task.go
+++ b/handler/task.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/alde/eremetic/types"
 	"github.com/gogo/protobuf/proto"
@@ -11,30 +10,14 @@ import (
 	"github.com/mesos/mesos-go/mesosutil"
 )
 
-type eremeticTask struct {
-	TaskCPUs    float64              `json:"task_cpus"`
-	TaskMem     float64              `json:"task_mem"`
-	Command     *mesos.CommandInfo   `json:"command"`
-	Container   *mesos.ContainerInfo `json:"container"`
-	Status      string               `json:"status"`
-	ID          string               `json:"id"`
-	Name        string               `json:"name"`
-	FrameworkId string               `json:"framework_id"`
-	SlaveId     string               `json:"slave_id"`
-	Hostname    string               `json:"hostname"`
-	deleteAt    time.Time
-}
-
-var runningTasks map[string]eremeticTask
-
 func createID(taskID string) string {
 	return fmt.Sprintf("eremetic-task.%s", taskID)
 }
 
-func createEremeticTask(request types.Request) (eremeticTask, error) {
+func createEremeticTask(request types.Request) (types.EremeticTask, error) {
 	randId, err := uuid.V4()
 	if err != nil {
-		return eremeticTask{}, err
+		return types.EremeticTask{}, err
 	}
 	taskId := createID(randId.String())
 
@@ -60,7 +43,7 @@ func createEremeticTask(request types.Request) (eremeticTask, error) {
 		Value: proto.String(taskId),
 	})
 
-	task := eremeticTask{
+	task := types.EremeticTask{
 		ID:       taskId,
 		TaskCPUs: request.TaskCPUs,
 		TaskMem:  request.TaskMem,
@@ -84,7 +67,7 @@ func createEremeticTask(request types.Request) (eremeticTask, error) {
 	return task, nil
 }
 
-func createTaskInfo(task *eremeticTask, offer *mesos.Offer) *mesos.TaskInfo {
+func createTaskInfo(task *types.EremeticTask, offer *mesos.Offer) *mesos.TaskInfo {
 	task.FrameworkId = *offer.FrameworkId.Value
 	task.SlaveId = *offer.SlaveId.Value
 	task.Hostname = *offer.Hostname

--- a/handler/task_test.go
+++ b/handler/task_test.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"testing"
-	"time"
 
 	"github.com/alde/eremetic/types"
 	"github.com/gogo/protobuf/proto"
@@ -33,7 +32,6 @@ func TestTask(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(task, ShouldNotBeNil)
 			So(task.Command.GetValue(), ShouldEqual, "echo hello")
-			So(task.deleteAt, ShouldBeZeroValue)
 			So(task.Container.GetType().String(), ShouldEqual, "DOCKER")
 			So(task.Container.Docker.GetImage(), ShouldEqual, "busybox")
 			So(task.Command.Environment.GetVariables(), ShouldHaveLength, 1)
@@ -63,7 +61,7 @@ func TestTask(t *testing.T) {
 	})
 
 	Convey("createTaskInfo", t, func() {
-		eremeticTask := eremeticTask{
+		eremeticTask := types.EremeticTask{
 			TaskCPUs:  0.2,
 			TaskMem:   0.5,
 			Command:   &mesos.CommandInfo{},
@@ -71,7 +69,6 @@ func TestTask(t *testing.T) {
 			Status:    "TASK_RUNNING",
 			ID:        "eremetic-task.1234",
 			Name:      "Eremetic task 17",
-			deleteAt:  time.Now(),
 		}
 		offer := mesos.Offer{
 			FrameworkId: &mesos.FrameworkID{

--- a/types/task.go
+++ b/types/task.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	mesos "github.com/mesos/mesos-go/mesosproto"
+)
+
+type EremeticTask struct {
+	TaskCPUs    float64              `json:"task_cpus"`
+	TaskMem     float64              `json:"task_mem"`
+	Command     *mesos.CommandInfo   `json:"command"`
+	Container   *mesos.ContainerInfo `json:"container"`
+	Status      string               `json:"status"`
+	ID          string               `json:"id"`
+	Name        string               `json:"name"`
+	FrameworkId string               `json:"framework_id"`
+	SlaveId     string               `json:"slave_id"`
+	Hostname    string               `json:"hostname"`
+}


### PR DESCRIPTION
Instead of having tasks in memory, store them in a Key/Value database.

Database will by default be created in db/eremetic.db relative to the
executable if nothing else is configured.

Removes the 1 hour time limit on reading requests.

Refactored EremeticTask into types package.

solves #12 