### PR TITLE
Fix messenger address in container

### DIFF
--- a/docker/marathon.sh
+++ b/docker/marathon.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 lookup_host() {
-    nslookup "$1" | awk -v HOST="$1" '{ if ($2 == HOST) { getline; gsub(/^.*: /, ""); split($0, a, " ", seps); print a[1]; } }'
+    nslookup "$1" | awk -v HOST="$1" '{ if ($2 == HOST) { getline; gsub(/^.*: /, ""); print $1 } }'
 }
 
 export MESSENGER_ADDRESS=`lookup_host ${HOST}${DOMAIN:+.$DOMAIN}`

--- a/docker/marathon.sh
+++ b/docker/marathon.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 lookup_host() {
-    nslookup "$1" | awk -v HOST="$1" '{ if ($2 == HOST) { getline; gsub(/^.*: /, ""); print; } }'
+    nslookup "$1" | awk -v HOST="$1" '{ if ($2 == HOST) { getline; gsub(/^.*: /, ""); split($0, a, " ", seps); print a[1]; } }'
 }
 
 export MESSENGER_ADDRESS=`lookup_host ${HOST}${DOMAIN:+.$DOMAIN}`


### PR DESCRIPTION
A small fix for the issue I hit - #36. 

Still no idea why `nslookup` inside container returns two adresses in one line, but this fix works for me. 
